### PR TITLE
Quote $XDG_DATA_HOME when setting error file

### DIFF
--- a/bin/autojump.fish
+++ b/bin/autojump.fish
@@ -13,7 +13,7 @@ complete -x -c j -a '(autojump --complete (commandline -t))'
 # set error file location
 if test (uname) = "Darwin"
     set -x AUTOJUMP_ERROR_PATH ~/Library/autojump/errors.log
-else if test -d $XDG_DATA_HOME
+else if test -d "$XDG_DATA_HOME"
     set -x AUTOJUMP_ERROR_PATH $XDG_DATA_HOME/autojump/errors.log
 else
     set -x AUTOJUMP_ERROR_PATH ~/.local/share/autojump/errors.log


### PR DESCRIPTION
I'm not sure if this is actually a bug in fish, but `test -d` with no argument returns true, and nonexistent environment variables return an empty string, so `test -d $XDG_DATA_HOME` becomes `test -d` and returns true when `$XDG_DATA_HOME` isn't set. `test -d "$XDG_DATA_HOME"` becomes `test -d ""` and returns false as expected.

Prior to making this change, I would get an error from `dirname` when opening a shell and an error from fish when `cd`ing.