### PR TITLE
Correct return from autojump_add_to_database in bash.

### DIFF
--- a/bin/autojump.bash
+++ b/bin/autojump.bash
@@ -36,11 +36,13 @@ complete -F _autojump j
 
 # change pwd hook
 autojump_add_to_database() {
+    local ret_value="$?"
     if [[ -f "${AUTOJUMP_ERROR_PATH}" ]]; then
         (autojump --add "$(pwd)" >/dev/null 2>>${AUTOJUMP_ERROR_PATH} &) &>/dev/null
     else
         (autojump --add "$(pwd)" >/dev/null &) &>/dev/null
     fi
+    return "$ret_value"
 }
 
 case $PROMPT_COMMAND in


### PR DESCRIPTION
By default autojump_add_to_database changed the value of $? (typically to 0) so if other functions was hooked to $PROMPT_COMMAND after this function they couldn't get the correct return value of the previous interactive bash command through "$?" (example: some prompt colorizing function which depends on $?). This commit fixes this.

Note: this is not a problem if autojump is the last library sourced from .bashrc since it puts autojump at the end of $PROMPT_COMMAND. However if multiple $PROMPT_COMMAND function from different bash sources relied on being the last one it could be a problem.